### PR TITLE
Correct connection type

### DIFF
--- a/symbols/BoardEdgeConnectors.kicad_sym
+++ b/symbols/BoardEdgeConnectors.kicad_sym
@@ -64,7 +64,7 @@
 			)
 		)
 		(symbol "TE-5530843-4_1_1"
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 26.67 0)
 				(length 3.81)
 				(name "A1"
@@ -82,7 +82,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 3.81 0)
 				(length 3.81)
 				(name "A10"
@@ -100,7 +100,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 1.27 0)
 				(length 3.81)
 				(name "A11"
@@ -118,7 +118,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -1.27 0)
 				(length 3.81)
 				(name "A12"
@@ -136,7 +136,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -3.81 0)
 				(length 3.81)
 				(name "A13"
@@ -154,7 +154,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -6.35 0)
 				(length 3.81)
 				(name "A14"
@@ -172,7 +172,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -8.89 0)
 				(length 3.81)
 				(name "A15"
@@ -190,7 +190,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -11.43 0)
 				(length 3.81)
 				(name "A16"
@@ -208,7 +208,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -13.97 0)
 				(length 3.81)
 				(name "A17"
@@ -226,7 +226,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -16.51 0)
 				(length 3.81)
 				(name "A18"
@@ -244,7 +244,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -19.05 0)
 				(length 3.81)
 				(name "A19"
@@ -262,7 +262,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 24.13 0)
 				(length 3.81)
 				(name "A2"
@@ -280,7 +280,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -21.59 0)
 				(length 3.81)
 				(name "A20"
@@ -298,7 +298,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -24.13 0)
 				(length 3.81)
 				(name "A21"
@@ -316,7 +316,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 -26.67 0)
 				(length 3.81)
 				(name "A22"
@@ -334,7 +334,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 21.59 0)
 				(length 3.81)
 				(name "A3"
@@ -352,7 +352,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 19.05 0)
 				(length 3.81)
 				(name "A4"
@@ -370,7 +370,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 16.51 0)
 				(length 3.81)
 				(name "A5"
@@ -388,7 +388,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 13.97 0)
 				(length 3.81)
 				(name "A6"
@@ -406,7 +406,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 11.43 0)
 				(length 3.81)
 				(name "A7"
@@ -424,7 +424,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 8.89 0)
 				(length 3.81)
 				(name "A8"
@@ -442,7 +442,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at -10.16 6.35 0)
 				(length 3.81)
 				(name "A9"
@@ -460,7 +460,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 26.67 180)
 				(length 3.81)
 				(name "B1"
@@ -478,7 +478,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 3.81 180)
 				(length 3.81)
 				(name "B10"
@@ -496,7 +496,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 1.27 180)
 				(length 3.81)
 				(name "B11"
@@ -514,7 +514,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -1.27 180)
 				(length 3.81)
 				(name "B12"
@@ -532,7 +532,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -3.81 180)
 				(length 3.81)
 				(name "B13"
@@ -550,7 +550,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -6.35 180)
 				(length 3.81)
 				(name "B14"
@@ -568,7 +568,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -8.89 180)
 				(length 3.81)
 				(name "B15"
@@ -586,7 +586,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -11.43 180)
 				(length 3.81)
 				(name "B16"
@@ -604,7 +604,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -13.97 180)
 				(length 3.81)
 				(name "B17"
@@ -622,7 +622,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -16.51 180)
 				(length 3.81)
 				(name "B18"
@@ -640,7 +640,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -19.05 180)
 				(length 3.81)
 				(name "B19"
@@ -658,7 +658,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 24.13 180)
 				(length 3.81)
 				(name "B2"
@@ -676,7 +676,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -21.59 180)
 				(length 3.81)
 				(name "B20"
@@ -694,7 +694,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -24.13 180)
 				(length 3.81)
 				(name "B21"
@@ -712,7 +712,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 -26.67 180)
 				(length 3.81)
 				(name "B22"
@@ -730,7 +730,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 21.59 180)
 				(length 3.81)
 				(name "B3"
@@ -748,7 +748,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 19.05 180)
 				(length 3.81)
 				(name "B4"
@@ -766,7 +766,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 16.51 180)
 				(length 3.81)
 				(name "B5"
@@ -784,7 +784,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 13.97 180)
 				(length 3.81)
 				(name "B6"
@@ -802,7 +802,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 11.43 180)
 				(length 3.81)
 				(name "B7"
@@ -820,7 +820,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 8.89 180)
 				(length 3.81)
 				(name "B8"
@@ -838,7 +838,7 @@
 					)
 				)
 			)
-			(pin unspecified line
+			(pin passive line
 				(at 10.16 6.35 180)
 				(length 3.81)
 				(name "B9"


### PR DESCRIPTION
The edge connector needs to have 'passive' connections, not unspecified. Otherwise, the design rules complain a lot.